### PR TITLE
Use total as state_class

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/realtime_device_data_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/realtime_device_data_sensor.py
@@ -1,7 +1,8 @@
 import datetime
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING, SensorEntity
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT, STATE_CLASS_TOTAL_INCREASING, STATE_CLASS_TOTAL, \
+    SensorEntity
 from homeassistant.components.binary_sensor import DEVICE_CLASS_CONNECTIVITY, BinarySensorEntity
 from homeassistant.const import DEVICE_CLASS_VOLTAGE, ELECTRIC_POTENTIAL_VOLT, DEVICE_CLASS_CURRENT, \
     ELECTRIC_CURRENT_AMPERE, DEVICE_CLASS_ENERGY, DEVICE_CLASS_TEMPERATURE, \
@@ -169,11 +170,7 @@ class FusionSolarRealtimeDeviceDataEnergySensor(FusionSolarRealtimeDeviceDataSen
 
     @property
     def state_class(self) -> str:
-        return STATE_CLASS_MEASUREMENT
-
-    @property
-    def last_reset(self) -> None:
-        return None
+        return STATE_CLASS_TOTAL
 
 
 class FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor(FusionSolarRealtimeDeviceDataEnergySensor):


### PR DESCRIPTION
For some reason a warning is shown if we use `state_class=measurement` in the Energy Dashboard configuration. See https://github.com/tijsverkoyen/HomeAssistant-FusionSolar/issues/18