### PR TITLE
Translate the state of the entities from status codes to readable data

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/realtime_device_data_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/realtime_device_data_sensor.py
@@ -63,72 +63,10 @@ class FusionSolarRealtimeDeviceDataSensor(CoordinatorEntity, SensorEntity):
         return self._device_info
 
 
-class FusionSolarRealtimeDeviceDataReadableInverterStateSensor(FusionSolarRealtimeDeviceDataSensor):
+class FusionSolarRealtimeDeviceDataTranslatedSensor(FusionSolarRealtimeDeviceDataSensor):
     @property
-    def unique_id(self) -> str:
-        return f'{DOMAIN}-{self._device.device_id}-readable-{self._attribute}'
-
-    @property
-    def state(self) -> str:
-        state = super().state
-
-        if state is None:
-            return None
-
-        if state == 0:
-            return "Standby: initializing"
-        if state == 1:
-            return "Standby: insulation resistance detection"
-        if state == 2:
-            return "Standby: sunlight detection"
-        if state == 3:
-            return "Standby: power grid detection"
-        if state == 256:
-            return "Start"
-        if state == 512:
-            return "Grid connection"
-        if state == 513:
-            return "Grid connection: limited power"
-        if state == 514:
-            return "Grid connection: self-derating"
-        if state == 768:
-            return "Shutdown: unexpected shutdown"
-        if state == 769:
-            return "Shutdown: commanded shutdown"
-        if state == 770:
-            return "Shutdown: OVGR"
-        if state == 771:
-            return "Shutdown: communication disconnection"
-        if state == 772:
-            return "Shutdown: limited power"
-        if state == 773:
-            return "Shutdown: manual startup is required"
-        if state == 774:
-            return "Shutdown: DC switch disconnected"
-        if state == 1025:
-            return "Grid scheduling: cosψ-P curve"
-        if state == 1026:
-            return "Grid scheduling: Q-U curve"
-        if state == 1280:
-            return "Spot-check ready"
-        if state == 1281:
-            return "Spot-checking"
-        if state == 1536:
-            return "Inspecting"
-        if state == 1792:
-            return "AFCI self-check"
-        if state == 2048:
-            return "I-V scanning"
-        if state == 2304:
-            return "DC input detection"
-        if state == 40960:
-            return "Standby: no sunlight"
-        if state == 45056:
-            return "Communication disconnection (written by the SmartLogger)"
-        if state == 49152:
-            return "Loading (written by the SmartLogger)"
-
-        return state
+    def translation_key(self) -> str:
+        return self._attribute
 
 
 class FusionSolarRealtimeDeviceDataVoltageSensor(FusionSolarRealtimeDeviceDataSensor):
@@ -325,98 +263,6 @@ class FusionSolarRealtimeDeviceDataTimestampSensor(FusionSolarRealtimeDeviceData
             return None
 
         return datetime.datetime.fromtimestamp(state / 1000)
-
-
-class FusionSolarRealtimeDeviceDataReadableRunStateSensor(FusionSolarRealtimeDeviceDataSensor):
-    @property
-    def unique_id(self) -> str:
-        return f'{DOMAIN}-{self._device.device_id}-readable-{self._attribute}'
-
-    @property
-    def state(self) -> float:
-        state = super().state
-
-        if state is None:
-            return None
-
-        if state == 0:
-            return "disconnected"
-        if state == 1:
-            return "connected"
-
-        return None
-
-
-class FusionSolarRealtimeDeviceDataReadableChargeDischargeModeSensor(FusionSolarRealtimeDeviceDataSensor):
-    @property
-    def unique_id(self) -> str:
-        return f'{DOMAIN}-{self._device.device_id}-readable-{self._attribute}'
-
-    @property
-    def state(self) -> float:
-        state = super().state
-
-        if state is None:
-            return None
-
-        if state == 0:
-            return "none"
-        if state == 1:
-            return "forced charge/discharge"
-        if state == 2:
-            return "time-of-use price"
-        if state == 3:
-            return "fixed charge/discharge"
-        if state == 4:
-            return "automatic charge/discharge"
-
-        return None
-
-
-class FusionSolarRealtimeDeviceDataReadableBatteryStatusSensor(FusionSolarRealtimeDeviceDataSensor):
-    @property
-    def unique_id(self) -> str:
-        return f'{DOMAIN}-{self._device.device_id}-readable-{self._attribute}'
-
-    @property
-    def state(self) -> float:
-        state = super().state
-
-        if state is None:
-            return None
-
-        if state == 0:
-            return "offline"
-        if state == 1:
-            return "standby"
-        if state == 2:
-            return "running"
-        if state == 3:
-            return "faulty"
-        if state == 4:
-            return "hibernation"
-
-        return None
-
-
-class FusionSolarRealtimeDeviceDataReadableMeterStatusSensor(FusionSolarRealtimeDeviceDataSensor):
-    @property
-    def unique_id(self) -> str:
-        return f'{DOMAIN}-{self._device.device_id}-readable-{self._attribute}'
-
-    @property
-    def state(self) -> float:
-        state = super().state
-
-        if state is None:
-            return None
-
-        if state == 0:
-            return "offline"
-        if state == 1:
-            return "normal"
-
-        return None
 
 
 class FusionSolarRealtimeDeviceDataBinarySensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/fusion_solar/sensor.py
+++ b/custom_components/fusion_solar/sensor.py
@@ -345,10 +345,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_STRING_INVERTER:
             entities_to_create = [
-                {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'inverter_state',
+                {'class': 'FusionSolarRealtimeDeviceDataTranslatedSensor', 'attribute': 'inverter_state',
                  'name': 'Inverter status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableInverterStateSensor', 'attribute': 'inverter_state',
-                 'name': 'Readable inverter status'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'ab_u', 'name': 'Grid AB voltage'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'bc_u', 'name': 'Grid BC voltage'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'ca_u', 'name': 'Grid CA voltage'},
@@ -370,7 +368,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                  'name': 'Active power'},
                 {'class': 'FusionSolarRealtimeDeviceDataReactivePowerSensor', 'attribute': 'reactive_power',
                  'name': 'Reactive output power'},
-                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'day_cap', 'name': 'Yield Today'},
+                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'day_cap',
+                 'name': 'Yield Today'},
                 {'class': 'FusionSolarRealtimeDeviceDataPowerSensor', 'attribute': 'mppt_power',
                  'name': 'MPPT total input power'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'pv1_u',
@@ -469,7 +468,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                  'name': 'PV23 input current'},
                 {'class': 'FusionSolarRealtimeDeviceDataCurrentSensor', 'attribute': 'pv24_i',
                  'name': 'PV24 input current'},
-                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'total_cap', 'name': 'Total yield'},
+                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'total_cap',
+                 'name': 'Total yield'},
                 {'class': 'FusionSolarRealtimeDeviceDataTimestampSensor', 'attribute': 'open_time',
                  'name': 'Inverter startup time'},
                 {'class': 'FusionSolarRealtimeDeviceDataTimestampSensor', 'attribute': 'close_time',
@@ -495,8 +495,6 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                 {'class': 'FusionSolarRealtimeDeviceDataEnergySensor', 'attribute': 'mppt_10_cap',
                  'name': 'MPPT 10 DC total yield'},
                 {'class': 'FusionSolarRealtimeDeviceDataStateBinarySensor', 'attribute': 'run_state', 'name': 'Status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableRunStateSensor', 'attribute': 'run_state',
-                 'name': 'Readable status'},
             ]
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_EMI:
@@ -517,8 +515,6 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                 {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'horiz_radiant_total',
                  'name': 'Horizontal irradiation'},
                 {'class': 'FusionSolarRealtimeDeviceDataStateBinarySensor', 'attribute': 'run_state', 'name': 'Status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableRunStateSensor', 'attribute': 'run_state',
-                 'name': 'Readable status'},
             ]
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_GRID_METER:
@@ -598,10 +594,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_RESIDENTIAL_INVERTER:
             entities_to_create = [
-                {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'inverter_state',
+                {'class': 'FusionSolarRealtimeDeviceDataTranslatedSensor', 'attribute': 'inverter_state',
                  'name': 'Inverter status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableInverterStateSensor', 'attribute': 'inverter_state',
-                 'name': 'Readable inverter status'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'ab_u', 'name': 'Grid AB voltage'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'bc_u', 'name': 'Grid BC voltage'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'ca_u', 'name': 'Grid CA voltage'},
@@ -623,7 +617,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                  'name': 'Active power'},
                 {'class': 'FusionSolarRealtimeDeviceDataReactivePowerSensor', 'attribute': 'reactive_power',
                  'name': 'Reactive output power'},
-                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'day_cap', 'name': 'Yield Today'},
+                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'day_cap',
+                 'name': 'Yield Today'},
                 {'class': 'FusionSolarRealtimeDeviceDataPowerSensor', 'attribute': 'mppt_power',
                  'name': 'MPPT total input power'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'pv1_u',
@@ -658,7 +653,8 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                  'name': 'PV7 input current'},
                 {'class': 'FusionSolarRealtimeDeviceDataCurrentSensor', 'attribute': 'pv8_i',
                  'name': 'PV8 input current'},
-                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'total_cap', 'name': 'Total yield'},
+                {'class': 'FusionSolarRealtimeDeviceDataEnergyTotalIncreasingSensor', 'attribute': 'total_cap',
+                 'name': 'Total yield'},
                 {'class': 'FusionSolarRealtimeDeviceDataTimestampSensor', 'attribute': 'open_time',
                  'name': 'Inverter startup time'},
                 {'class': 'FusionSolarRealtimeDeviceDataTimestampSensor', 'attribute': 'close_time',
@@ -672,16 +668,12 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                 {'class': 'FusionSolarRealtimeDeviceDataEnergySensor', 'attribute': 'mppt_4_cap',
                  'name': 'MPPT 4 DC total yield'},
                 {'class': 'FusionSolarRealtimeDeviceDataStateBinarySensor', 'attribute': 'run_state', 'name': 'Status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableRunStateSensor', 'attribute': 'run_state',
-                 'name': 'Readable status'},
             ]
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_BATTERY:
             entities_to_create = [
-                {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'battery_status',
+                {'class': 'FusionSolarRealtimeDeviceDataTranslatedSensor', 'attribute': 'battery_status',
                  'name': 'Battery running status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableBatteryStatusSensor', 'attribute': 'battery_status',
-                 'name': 'Readable battery running status'},
                 {'class': 'FusionSolarRealtimeDeviceDataPowerInWattSensor', 'attribute': 'max_charge_power',
                  'name': 'Maximum charge power'},
                 {'class': 'FusionSolarRealtimeDeviceDataPowerInWattSensor', 'attribute': 'max_discharge_power',
@@ -694,24 +686,18 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                  'name': 'Battery state of charge (SOC)'},
                 {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'battery_soh',
                  'name': 'Battery state of health (SOH)'},
-                {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'ch_discharge_model',
+                {'class': 'FusionSolarRealtimeDeviceDataTranslatedSensor', 'attribute': 'ch_discharge_model',
                  'name': 'Charge/Discharge mode'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableChargeDischargeModeSensor',
-                 'attribute': 'ch_discharge_model', 'name': 'Readable charge/Discharge mode'},
                 {'class': 'FusionSolarRealtimeDeviceDataEnergySensor', 'attribute': 'charge_cap',
                  'name': 'Charging capacity'},
                 {'class': 'FusionSolarRealtimeDeviceDataEnergySensor', 'attribute': 'discharge_cap',
                  'name': 'Discharging capacity'},
                 {'class': 'FusionSolarRealtimeDeviceDataStateBinarySensor', 'attribute': 'run_state', 'name': 'Status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableRunStateSensor', 'attribute': 'run_state',
-                 'name': 'Readable status'},
             ]
 
         if device.type_id == PARAM_DEVICE_TYPE_ID_POWER_SENSOR:
             entities_to_create = [
-                {'class': 'FusionSolarRealtimeDeviceDataSensor', 'attribute': 'meter_status', 'name': 'Meter status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableMeterStatusSensor', 'attribute': 'meter_status',
-                 'name': 'Meter status'},
+                {'class': 'FusionSolarRealtimeDeviceDataTranslatedSensor', 'attribute': 'meter_status', 'name': 'Meter status'},
                 {'class': 'FusionSolarRealtimeDeviceDataVoltageSensor', 'attribute': 'meter_u', 'name': 'Grid voltage'},
                 {'class': 'FusionSolarRealtimeDeviceDataCurrentSensor', 'attribute': 'meter_i', 'name': 'Grid current'},
                 {'class': 'FusionSolarRealtimeDeviceDataPowerInWattSensor', 'attribute': 'active_power',
@@ -727,8 +713,6 @@ async def add_entities_for_stations(hass, async_add_entities, stations, api: Fus
                 {'class': 'FusionSolarRealtimeDeviceDataEnergySensor', 'attribute': 'reverse_active_cap',
                  'name': 'Reverse active energy'},
                 {'class': 'FusionSolarRealtimeDeviceDataStateBinarySensor', 'attribute': 'run_state', 'name': 'Status'},
-                {'class': 'FusionSolarRealtimeDeviceDataReadableRunStateSensor', 'attribute': 'run_state',
-                 'name': 'Readable status'},
             ]
 
         entities = []

--- a/custom_components/fusion_solar/strings.json
+++ b/custom_components/fusion_solar/strings.json
@@ -29,5 +29,63 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "battery_status": {
+        "state": {
+          "0.0": "offline",
+          "1.0": "standby",
+          "2.0": "running",
+          "3.0": "faulty",
+          "4.0": "hibernation"
+        }
+      },
+      "ch_discharge_model": {
+        "state": {
+          "0.0": "none",
+          "1.0": "forced charge/discharge",
+          "2.0": "time-of-use price",
+          "3.0": "fixed charge/discharge",
+          "4.0": "automatic charge/discharge"
+        }
+      },
+      "meter_status": {
+        "state": {
+          "0.0": "offline",
+          "1.0": "normal"
+        }
+      },
+      "inverter_state": {
+        "state": {
+          "0.0": "Standby: initializing",
+          "1.0": "Standby: insulation resistance detection",
+          "2.0": "Standby: sunlight detection",
+          "3.0": "Standby: power grid detection",
+          "256.0": "Start",
+          "512.0": "Grid connection",
+          "513.0": "Grid connection: limited power",
+          "514.0": "Grid connection: self-derating",
+          "768.0": "Shutdown: unexpected shutdown",
+          "769.0": "Shutdown: commanded shutdown",
+          "770.0": "Shutdown: OVGR",
+          "771.0": "Shutdown: communication disconnection",
+          "772.0": "Shutdown: limited power",
+          "773.0": "Shutdown: manual startup is required",
+          "774.0": "Shutdown: DC switch disconnected",
+          "1025.0": "Grid scheduling: cosψ-P curve",
+          "1026.0": "Grid scheduling: Q-U curve",
+          "1280.0": "Spot-check ready",
+          "1281.0": "Spot-checking",
+          "1536.0": "Inspecting",
+          "1792.0": "AFCI self-check",
+          "2048.0": "I-V scanning",
+          "2304.0": "DC input detection",
+          "40960.0": "Standby: no sunlight",
+          "45056.0": "Communication disconnection (written by the SmartLogger)",
+          "49152.0": "Loading (written by the SmartLogger)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/fusion_solar/translations/en.json
+++ b/custom_components/fusion_solar/translations/en.json
@@ -29,5 +29,63 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "battery_status": {
+        "state": {
+          "0.0": "offline",
+          "1.0": "standby",
+          "2.0": "running",
+          "3.0": "faulty",
+          "4.0": "hibernation"
+        }
+      },
+      "ch_discharge_model": {
+        "state": {
+          "0.0": "none",
+          "1.0": "forced charge/discharge",
+          "2.0": "time-of-use price",
+          "3.0": "fixed charge/discharge",
+          "4.0": "automatic charge/discharge"
+        }
+      },
+      "meter_status": {
+        "state": {
+          "0.0": "offline",
+          "1.0": "normal"
+        }
+      },
+      "inverter_state": {
+        "state": {
+          "0.0": "Standby: initializing",
+          "1.0": "Standby: insulation resistance detection",
+          "2.0": "Standby: sunlight detection",
+          "3.0": "Standby: power grid detection",
+          "256.0": "Start",
+          "512.0": "Grid connection",
+          "513.0": "Grid connection: limited power",
+          "514.0": "Grid connection: self-derating",
+          "768.0": "Shutdown: unexpected shutdown",
+          "769.0": "Shutdown: commanded shutdown",
+          "770.0": "Shutdown: OVGR",
+          "771.0": "Shutdown: communication disconnection",
+          "772.0": "Shutdown: limited power",
+          "773.0": "Shutdown: manual startup is required",
+          "774.0": "Shutdown: DC switch disconnected",
+          "1025.0": "Grid scheduling: cosψ-P curve",
+          "1026.0": "Grid scheduling: Q-U curve",
+          "1280.0": "Spot-check ready",
+          "1281.0": "Spot-checking",
+          "1536.0": "Inspecting",
+          "1792.0": "AFCI self-check",
+          "2048.0": "I-V scanning",
+          "2304.0": "DC input detection",
+          "40960.0": "Standby: no sunlight",
+          "45056.0": "Communication disconnection (written by the SmartLogger)",
+          "49152.0": "Loading (written by the SmartLogger)"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
**Remark: Can only be released when HA 2023.1 has been released**

Some entities are not available anymore:
* `xxx-readable_battery_status`
* `xxx-readable_ch_discharge_model `
* `xxx-readable_meter_status `
* `xxx-readable_ inverter_state `

See https://developers.home-assistant.io/blog/2022/12/01/entity_translations/ for more information