### PR TITLE
Don't update state when we are in rate limiting mode

### DIFF
--- a/custom_components/fusion_solar/device_real_kpi_coordinator.py
+++ b/custom_components/fusion_solar/device_real_kpi_coordinator.py
@@ -49,7 +49,7 @@ class DeviceRealKpiDataCoordinator(DataUpdateCoordinator):
         self.counter += 1
 
         try:
-            _LOGGER.debug(f'{self.name} Fetching data for {type_id_to_fetch}')
+            _LOGGER.debug(f'{self.name} Fetching data for type ID: {type_id_to_fetch}')
             response = await self.hass.async_add_executor_job(
                 self.api.get_dev_real_kpi,
                 device_ids_grouped_per_type_id[type_id_to_fetch],

--- a/custom_components/fusion_solar/fusion_solar/power_entity.py
+++ b/custom_components/fusion_solar/fusion_solar/power_entity.py
@@ -1,6 +1,7 @@
+from homeassistant.core import callback
+from homeassistant.const import DEVICE_CLASS_POWER, UnitOfPower
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import DEVICE_CLASS_POWER, UnitOfPower
 
 
 class FusionSolarPowerEntity(CoordinatorEntity, Entity):
@@ -22,6 +23,7 @@ class FusionSolarPowerEntity(CoordinatorEntity, Entity):
         self._attribute = attribute
         self._data_name = data_name
         self._device_info = device_info
+        self._state = '__NOT_INITIALIZED__'
 
     @property
     def device_class(self):
@@ -37,12 +39,14 @@ class FusionSolarPowerEntity(CoordinatorEntity, Entity):
 
     @property
     def state(self):
-        if self._data_name not in self.coordinator.data:
-            return None
-        if self._attribute not in self.coordinator.data[self._data_name]:
+        if self._state == '__NOT_INITIALIZED__':
+            # check if data is available
+            self._handle_coordinator_update()
+
+        if self._state is None or self._state == '__NOT_INITIALIZED__':
             return None
 
-        return float(self.coordinator.data[self._data_name][self._attribute])
+        return self._state
 
     @property
     def unit_of_measurement(self):
@@ -51,6 +55,22 @@ class FusionSolarPowerEntity(CoordinatorEntity, Entity):
     @property
     def device_info(self) -> dict:
         return self._device_info
+
+    @callback
+    def _handle_coordinator_update(self):
+        if self.coordinator.data is False:
+            return
+        if self._data_name not in self.coordinator.data:
+            return
+        if self._attribute not in self.coordinator.data[self._data_name]:
+            return
+
+        if self.coordinator.data[self._data_name][self._attribute] is None:
+            self._state = None
+        elif self.coordinator.data[self._data_name][self._attribute] == 'N/A':
+            self._state = None
+        else:
+            self._state = float(self.coordinator.data[self._data_name][self._attribute])
 
 
 class FusionSolarPowerEntityRealtime(FusionSolarPowerEntity):

--- a/custom_components/fusion_solar/sensor.py
+++ b/custom_components/fusion_solar/sensor.py
@@ -588,8 +588,6 @@ async def _add_entities_for_stations_real_kpi_data(hass, async_add_entities, sta
         for response_data in response:
             data[f'{DOMAIN}-{response_data[ATTR_STATION_CODE]}'] = response_data[ATTR_STATION_REAL_KPI_DATA_ITEM_MAP]
 
-        _LOGGER.debug(f'async_update_station_real_kpi_data: {data}')
-
         return data
 
     coordinator = DataUpdateCoordinator(


### PR DESCRIPTION
If the UpdateFailedException is thrown the entities become unavailable, while the last value makes more sense

Rewrote the handling of the received data to only update the state when data is received

Should fix: https://github.com/tijsverkoyen/HomeAssistant-FusionSolar/issues/29