### PR TITLE
Cleanup incomplete PR 48

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/energy_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/energy_sensor.py
@@ -67,19 +67,6 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
                         f'{self.entity_id}: not producing any power, so not updating to prevent positive glitched.')
                     return float(current_value)
 
-                if not isfloat(new_value):
-                    _LOGGER.warning(f'{self.entity_id}: new value ({new_value}) is not a float, so not updating.')
-                    return float(current_value)
-
-                if not isfloat(current_value):
-                    _LOGGER.warning(f'{self.entity_id}: current value ({current_value}) is not a float, send 0.')
-                    return 0
-
-                if float(new_value) < float(current_value):
-                    _LOGGER.debug(
-                        f'{self.entity_id}: new value ({new_value}) is smaller then current value ({entity.state}), so not updating.')
-                    return float(current_value)
-
         if self._data_name not in self.coordinator.data:
             return None
 


### PR DESCRIPTION
This old attempt to handle negative "glitches" should be removed. New method handles both negative and positive. There are also ill side effects in the old method, one should never return 0 on this type of entity. 
Ref issue #4
/A
