### PR TITLE
Ignore devices that are disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ request from Huawei. But the names are pretty self-explanatory.
 
 The realtime data is updated every minute per device group. As the API only allows 1 call per minute to each
 endpoint and the same endpoint is needed for each device group. So the more different devices you have the slower
-the update will be.
+the update will be. See [Disabling devices](#disabling-devices)
 
 ### Total yields
 
@@ -78,9 +78,18 @@ Your plant, inverter(s), batteries, ... expose a lot of entities, you can see th
 Integrations → Click on the "x devices" on the Fusion Solar Integration. Click on the device you want to see the
 entities for.
 
-### What does all entities mean?
+### What do all entities mean?
 
 As I don't own an installation with all possible devices this integration is mostly based on
 the [Northbound Interface Reference](/docs/smartpvms-v500r007c00-northbound-interface-reference.pdf).
 
 The entity names are based on the names in the interface reference.
+
+### Disabling devices
+
+If you have a lot of devices wherefor you don't want to use the data. You can disable them through the interface:
+Settings → Devices & Integrations → Click on the "x devices" on the Fusion Solar Integration. Click on the device you
+want to disable. Click on the pencil icon in the upper right corner. Switch off "Enable device".
+
+This can speed up the updating of the other devices. Keep in mind that a call is made per device type. So if you have
+multiple devices from the same time you need to disable them all to have effect.

--- a/custom_components/fusion_solar/device_real_kpi_coordinator.py
+++ b/custom_components/fusion_solar/device_real_kpi_coordinator.py
@@ -3,6 +3,7 @@ import math
 import logging
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -68,6 +69,7 @@ class DeviceRealKpiDataCoordinator(DataUpdateCoordinator):
         return data
 
     def device_ids_grouped_per_type_id(self):
+        device_registry = dr.async_get(self.hass)
         device_ids_grouped_per_type_id = {}
 
         for device in self.devices:
@@ -75,6 +77,11 @@ class DeviceRealKpiDataCoordinator(DataUpdateCoordinator):
             if device.type_id not in [PARAM_DEVICE_TYPE_ID_STRING_INVERTER, PARAM_DEVICE_TYPE_ID_EMI,
                                       PARAM_DEVICE_TYPE_ID_GRID_METER, PARAM_DEVICE_TYPE_ID_RESIDENTIAL_INVERTER,
                                       PARAM_DEVICE_TYPE_ID_BATTERY, PARAM_DEVICE_TYPE_ID_POWER_SENSOR]:
+                continue
+
+            device_from_registry = device_registry.async_get_device(identifiers={(DOMAIN, device.device_id)})
+            if device_from_registry is not None and device_from_registry.disabled:
+                _LOGGER.debug(f'Device {device.name} ({device.device_id}) is disabled by the user.')
                 continue
 
             if device.type_id not in device_ids_grouped_per_type_id:


### PR DESCRIPTION
Ignore devices that are disabled through the Home Assistant interface.
This *can* speed up the process of receiving updates.

Should fix https://github.com/tijsverkoyen/HomeAssistant-FusionSolar/issues/49

Thx @catalinbordan for the insight