### PR TITLE
Increase update interval for total current year stats,

### DIFF
--- a/custom_components/fusion_solar/sensor.py
+++ b/custom_components/fusion_solar/sensor.py
@@ -675,7 +675,7 @@ async def _add_entities_for_stations_year_kpi_data(hass, async_add_entities, sta
         _LOGGER,
         name='FusionSolarOpenAPIStationYearKpi',
         update_method=async_update_station_year_kpi_data,
-        update_interval=timedelta(seconds=600),
+        update_interval=timedelta(hours=1),
     )
 
     # Fetch initial data so we have data when entities subscribe


### PR DESCRIPTION
The `getKpiStationYear` has traffic limiting. We can only call 25 times / day. In the documentation the following is found:

> Traffic limiting is performed based on the number of plants managed by
> northbound API users. Number of northbound API calls per user per day =
>   Roundup (Number of plants/100) + 24
>
> Only one concurrent request is supported per minute.
>
> If the access frequency exceeds the limit, the interface returns error code 407. Example:
> * If a user manages 20 plants, the maximum number of API calls per day = Roundup (20/100) + 24 = 1 + 24 = 25.
> * If a user manages 120 plants, the maximum number of API calls per day = Roundup (120/100) + 24 = 2 + 24 = 26.

For now I have set it to 1 update per hour to be on the safe side.