### PR TITLE
Added float type cast to fix OpenAPI returned string type.

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/energy_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/energy_sensor.py
@@ -65,7 +65,7 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
                     return
 
                 realtime_power = self.coordinator.data[self._data_name][ATTR_REALTIME_POWER]
-                if math.isclose(realtime_power, 0, abs_tol = 0.001):
+                if math.isclose(float(realtime_power), 0, abs_tol = 0.001):
                     _LOGGER.info(f'{self.entity_id}: not producing any power, so no energy update to prevent glitches.')
                     return float(current_value)
 


### PR DESCRIPTION
Quick-Fix for issue #132. Inconsistent data types from Kiosk and OpenAPI, float vs string, while the common code assumed float only. A float type cast will (probably) fix this. Needs to be verified on a OpenAPI installation, only tested by me on Kiosk.

A re-factoring to a more consistent use of data types is recommended as a long term proper correction. And in that case perhaps also take care of the midnight glitches in "yearEnergy" and "monthEnergy" data sets.