### PR TITLE
Update openapi_api.py

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/openapi/openapi_api.py
+++ b/custom_components/fusion_solar/fusion_solar/openapi/openapi_api.py
@@ -164,7 +164,7 @@ class FusionSolarOpenApi:
 
         headers = {
             'accept': 'application/json',
-            'xsrf-token': self._token,
+            'XSRF-TOKEN': self._token,
         }
 
         try:


### PR DESCRIPTION
## Description
Fixes the XSRF-Token header casing issue that causes `getStationList` endpoint to fail with failCode 20056.

## Problem
The current implementation uses lowercase `'xsrf-token'` as the header name, but the FusionSolar API expects uppercase `'XSRF-TOKEN'` as documented in the official Postman collection.

## Solution
- Changed header name from `'xsrf-token'` to `'XSRF-TOKEN'` in the [_do_call]
- This aligns with the official FusionSolar API specification

## Testing
- Verified against the Postman collection in [/docs/postman_collection.json]
- All API endpoints use `"XSRF-TOKEN"` (uppercase) in the official documentation

## Fixes
- Resolves #150 
- Fixes failCode 20056 authentication errors
- Restores functionality for `getStationList` endpoint