### PR TITLE
Fix total lifetime energy overnight drops

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/energy_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/energy_sensor.py
@@ -45,22 +45,25 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self) -> float:
         # It seems like Huawei Fusion Solar returns some invalid data for the cumulativeEnergy just before midnight.
-        # So we update the value only if the system is producing power at the moment.
+        # So we update the value only if it's increasing
         if ATTR_TOTAL_LIFETIME_ENERGY == self._attribute:
             # Grab the current data
             entity = self.hass.states.get(self.entity_id)
             if entity is not None:
+                new_value = self.get_float_value_from_coordinator(self._attribute)
                 try:
                     current_value = float(entity.state)
                 except ValueError:
                     _LOGGER.info(f'{self.entity_id}: not available, so no update to prevent issues.')
                     return
-
-                # Return the current value if the system is not producing
-                if not self.is_producing_at_the_moment():
-                    _LOGGER.info(f'{self.entity_id}: not producing any power, so no update to prevent glitches.')
-                    return current_value
-
+                if current_value is not None and new_value is not None:
+                    if new_value < current_value:
+                        _LOGGER.warning(
+                            f'{self.entity_id}: New value ({new_value}) is lower than current value ({current_value}). '
+                            f'Keeping current value to prevent decrease.'
+                        )
+                        # Return the current value if the new value is lower
+                        return current_value
         try:
             return self.get_float_value_from_coordinator(self._attribute)
         except FusionSolarEnergySensorException as e:

--- a/custom_components/fusion_solar/fusion_solar/energy_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/energy_sensor.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy
 
-from .const import ATTR_TOTAL_LIFETIME_ENERGY, ATTR_REALTIME_POWER
+from .const import ATTR_TOTAL_LIFETIME_ENERGY, ATTR_REALTIME_POWER, ATTR_STATION_REAL_KPI_TOTAL_LIFETIME_ENERGY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> float:
         # It seems like Huawei Fusion Solar returns some invalid data for the cumulativeEnergy just before midnight.
         # So we update the value only if it's increasing
-        if ATTR_TOTAL_LIFETIME_ENERGY == self._attribute:
+        if self._attribute in [ATTR_STATION_REAL_KPI_TOTAL_LIFETIME_ENERGY, ATTR_TOTAL_LIFETIME_ENERGY]:
             # Grab the current data
             entity = self.hass.states.get(self.entity_id)
             if entity is not None:
@@ -58,7 +58,7 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
                     return
                 if current_value is not None and new_value is not None:
                     if new_value < current_value:
-                        _LOGGER.warning(
+                        _LOGGER.error(
                             f'{self.entity_id}: New value ({new_value}) is lower than current value ({current_value}). '
                             f'Keeping current value to prevent decrease.'
                         )


### PR DESCRIPTION
Fixes #217 by not updating Total Lifetime Energy if the value obtained from API is smaller than the previous one.