### PR TITLE
feat: add integration reload support

### DIFF
--- a/custom_components/fusion_solar/__init__.py
+++ b/custom_components/fusion_solar/__init__.py
@@ -8,6 +8,8 @@ from homeassistant.const import Platform
 
 from .const import DOMAIN
 
+PLATFORMS: list[Platform] = [Platform.SENSOR]
+
 
 async def async_setup(hass: HomeAssistant, config: Config) -> bool:
     """Set up the FusionSolar component from yaml configuration."""
@@ -22,7 +24,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
     # Forward the setup to the sensor platform.
-    hass.add_job(
-        hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok


### PR DESCRIPTION
## Summary
Implements the ability to reload the FusionSolar integration from the Home Assistant UI without requiring a full system restart.

## Changes
- Added `async_unload_entry` function to properly clean up when the integration is reloaded
- Fixed `async_setup_entry` to properly `await` platform setup instead of using `hass.add_job()`
- Added `PLATFORMS` constant for cleaner platform management

## How to use
After this change, users can reload the integration via:
1. Go to Settings → Integrations → FusionSolar
2. Click the three dots menu (⋮)
3. Select "Reload"

This is useful when the integration gets stuck and allows setting up self-healing automations using `homeassistant.reload_config_entry`.

Fixes #263