### PR TITLE
Fix lifetime_energy sensor stuck on `unknown` after a missed coordinator refresh

### DIFF
--- a/custom_components/fusion_solar/fusion_solar/energy_sensor.py
+++ b/custom_components/fusion_solar/fusion_solar/energy_sensor.py
@@ -53,13 +53,16 @@ class FusionSolarEnergySensor(CoordinatorEntity, SensorEntity):
                 try:
                     current_value = float(entity.state)
                 except ValueError:
-                    _LOGGER.info(f'{self.entity_id}: not available, so no update to prevent issues.')
-                    return
-
-                # Return the current value if the system is not producing
-                if not self.is_producing_at_the_moment():
-                    _LOGGER.info(f'{self.entity_id}: not producing any power, so no update to prevent glitches.')
-                    return current_value
+                    # Previous state is unknown/unavailable. We have no anchor value,
+                    # so we cannot apply the "skip update if not producing" safeguard.
+                    # Fall through to the coordinator-driven update so the sensor can
+                    # recover instead of staying stuck in unknown forever.
+                    _LOGGER.info(f'{self.entity_id}: previous value unavailable, recovering from coordinator data.')
+                else:
+                    # Return the current value if the system is not producing
+                    if not self.is_producing_at_the_moment():
+                        _LOGGER.info(f'{self.entity_id}: not producing any power, so no update to prevent glitches.')
+                        return current_value
 
         try:
             return self.get_float_value_from_coordinator(self._attribute)

--- a/custom_components/fusion_solar/fusion_solar/kiosk/kiosk_api.py
+++ b/custom_components/fusion_solar/fusion_solar/kiosk/kiosk_api.py
@@ -29,7 +29,7 @@ class FusionSolarKioskApi:
             response = get(url, headers=headers)
             jsonData = response.json()
 
-            if ATTR_SUCCESS not in jsonData or not jsonData[ATTR_SUCCESS]:
+            if jsonData is None or ATTR_SUCCESS not in jsonData or not jsonData[ATTR_SUCCESS]:
                 raise FusionSolarKioskApiError(f'Retrieving the data failed. Raw response: {response.text}')
 
             # convert encoded html string to JSON


### PR DESCRIPTION
## Context

  In production I observed `sensor.<...>_total_lifetime_energy` get stuck on `unknown` for days, while the other kiosk sensors
  (`day`, `month`, `year`, `realtime_power`) kept updating normally. The Energy Dashboard's solar source (which reads
  `_total_lifetime_energy`) then shows a gap until manual intervention.

  This PR contains two small, independent fixes.

  ## Commit 1 — `energy_sensor.py`: don't trap the sensor in `unknown`

  `native_value` for `ATTR_TOTAL_LIFETIME_ENERGY` reads the previous state of the sensor as an anchor to skip updates when the 
  system is not producing (avoids the well-known midnight glitch from Huawei). When the previous state happens to be `unknown` / 
  `unavailable` — typically after a single failed coordinator refresh — `float(entity.state)` raises `ValueError` and the method 
  returns `None`, so the sensor stays on `unknown` **forever**, even when subsequent refreshes succeed.

  Without an anchor value, the "skip update if not producing" safeguard cannot apply meaningfully. Fall through to the 
  coordinator-driven update path instead, so the sensor recovers as soon as the API returns valid data again.

  ## Commit 2 — `kiosk_api.py`: guard against `null` JSON body

  `response.json()` returns `None` when the body is the JSON literal `null` (which I've observed coming through Huawei's CloudWAF
  when the upstream backend hiccups). The existing `ATTR_SUCCESS not in jsonData` check then raises `TypeError: argument of type
  'NoneType' is not a container or iterable`, which is not caught and bubbles up as `Unexpected error fetching FusionSolarKiosk
  data` every 10 minutes.

  Treating a `None` body as a regular API failure (`FusionSolarKioskApiError`) keeps the logs clean and lets the coordinator
  record a normal missed update. **Without commit 1, this transient failure is what triggers the stuck-`unknown` state in the 
  first place.**

  ## How to reproduce the stuck state

  1. Briefly knock out the API response (block the host, or just wait for a real `null` response — happens for me ~30% of
  cycles).
  2. The sensor goes to `unknown`.
  3. All subsequent successful refreshes log `not available, so no update to prevent issues` and the sensor never recovers.

  With this PR, step 3 logs `previous value unavailable, recovering from coordinator data` once, then the next
  non-zero-production cycle restores the real value.

  ## Test plan

  - [x] Trigger transient `null` response → sensor briefly `unknown`, recovers on next successful refresh (previously: stuck).
  - [x] Normal day/night cycle: lifetime value still doesn't shift while `realtime_power == 0` (midnight-glitch safeguard
  preserved when an anchor value exists).
  - [x] Other energy sensors (day/month/year) unaffected.